### PR TITLE
shepherds pie fixed potato type from Russet to Yukon

### DIFF
--- a/shepherds_pie.txt
+++ b/shepherds_pie.txt
@@ -24,7 +24,7 @@ For the lamb filling:
     Salt and freshly ground black pepper to taste
 
 For the mashed potato topping:
-    2 lbs russet potatoes, peeled and quartered
+    2 lbs Yukon potatoes, peeled and quartered
     1/2 cup milk (or half-and-half for extra creaminess)
     4 tablespoons unsalted butter
     Salt and freshly ground black pepper to taste
@@ -40,7 +40,7 @@ Instructions:
 
 1. Prepare the mashed potatoes:
 
-    Place the peeled and quartered potatoes in the large pot. Cover them with cold water and add a teaspoon of salt.
+    Place the peeled and quartered Yukon potatoes in the large pot. Cover them with cold water and add a teaspoon of salt.
     Bring to a boil and cook until the potatoes are fork-tender, about 15-20 minutes.
     Drain the potatoes well and return them to the pot.   
     Add the milk and butter. Mash until smooth and creamy. Season generously with salt and pepper to taste. Set aside.


### PR DESCRIPTION
Russet potatoes are subpar potatoes, so I think the user
should use Yukon potatoes for the mashed potato part
of the shepherd's pie.